### PR TITLE
Fix JSON typo

### DIFF
--- a/cookbook/sections/data-publishers/best-practices-publishing-station-based-observational-data.adoc
+++ b/cookbook/sections/data-publishers/best-practices-publishing-station-based-observational-data.adoc
@@ -25,6 +25,7 @@ WNM requires a `geometry` property, which allows for expressing the location of 
   "geometry": {
     "type": "Point",
     "coordinates": [-87.42188, 44.83941, 712]
+  }
 }
 ----
 


### PR DESCRIPTION
This change closes the "geometry" object in the example JSON