### PR TITLE
add recipe for WCMP2 publishing with links to stations

### DIFF
--- a/cookbook/sections/data-publishers/index.adoc
+++ b/cookbook/sections/data-publishers/index.adoc
@@ -10,6 +10,8 @@ include::publishing-wcmp2-retired-data.adoc[]
 
 include::publishing-wcmp2-provenance.adoc[]
 
+include::publishing-wcmp2-wigos-stations.adoc[]
+
 include::publishing-wnm-access-control.adoc[]
 
 include::publishing-wnm-access-embedded-data.adoc[]

--- a/cookbook/sections/data-publishers/publishing-wcmp2-provenance.adoc
+++ b/cookbook/sections/data-publishers/publishing-wcmp2-provenance.adoc
@@ -8,11 +8,11 @@ In WCMP2, one can provide linkages to provenance information via a dedicated lin
 [source,json]
 ----
 {
-    "rel": "describedBy",
+    "rel": "describedby",
     "type": "text/html",
     "title": "Provenance information for this dataset",
     "href": "https://example.org/dataset1.html"
 }
 ----
 
-As with any WCMP2 link, the URL itself is defined by the data publisher.  The ``describedBy`` attribute (which is an https://www.iana.org/assignments/link-relations/link-relations.xhtml[official IANA link relation]) is the signal for identifying data provenance by a user assessing and reviewing dataset history and lineage.
+As with any WCMP2 link, the URL itself is defined by the data publisher.  The ``describedby`` attribute (which is an https://www.iana.org/assignments/link-relations/link-relations.xhtml[official IANA link relation]) is the signal for identifying data provenance by a user assessing and reviewing dataset history and lineage.

--- a/cookbook/sections/data-publishers/publishing-wcmp2-wigos-stations.adoc
+++ b/cookbook/sections/data-publishers/publishing-wcmp2-wigos-stations.adoc
@@ -1,0 +1,31 @@
+=== Publishing a WMO Core Metadata Profile record referencing WIGOS stations and networks
+
+WCMP2 allows for publication of any data (observations, forecasts, warnings, etc.) with the principle of discovery metadata.  WIGOS metadata refers to station or observation metadata which is currently managed in the https://oscar.wmo.int/surface[OSCAR Surface] system.
+
+Given that various metadata are managed across distributed systems, WCMP2 links can be used to relate a given dataset of observations measured at a station or set of stations on OSCAR/Surface, or other/similar systems.
+
+.Referring to a station as a WCMP2 link
+[source,json]
+----
+{
+    "rel": "station",
+    "type": "application/xml",
+    "title": "Station report for Thessaloniki (Greece)",
+    "href": "https://oscar.wmo.int/surface/rest/api/wmd/download/0-20008-0-THE"
+}
+----
+
+.Referring to a set of stations as a WCMP2 link
+[source,json]
+----
+{
+    "rel": "stations",
+    "type": "text/html",
+    "title": "Davos Integrated CryoNet Cluster",
+    "href": "https://oscar.wmo.int/surface/#/search/stationClusterReport/8"
+}
+----
+
+A data publisher can decide whether to enumerate one link foreach station, or refer to a facility set of stations.  As an example, for a network of 50 stations, it would be more suitable to refer to the set of stations as a single `rel=stations` link.
+
+NOTE: Link relations are governed by https://www.iana.org/assignments/link-relations/link-relations.xhtml[IANA link relations] and WMO extensions as defined in WCMP2, available on the https://codes.wmo.int/wis/_link-type[WMO Codes Registry].

--- a/cookbook/sections/data-publishers/publishing-wcmp2-wigos-stations.adoc
+++ b/cookbook/sections/data-publishers/publishing-wcmp2-wigos-stations.adoc
@@ -10,7 +10,7 @@ Given that various metadata are managed across distributed systems, WCMP2 links 
 {
     "rel": "station",
     "type": "application/xml",
-    "title": "Station report for Thessaloniki (Greece)",
+    "title": "Station report details for Thessaloniki (Greece)",
     "href": "https://oscar.wmo.int/surface/rest/api/wmd/download/0-20008-0-THE"
 }
 ----


### PR DESCRIPTION
Addresses Referencing WIGOS stations and networks from discovery metadata in #16.